### PR TITLE
fragment-view

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface HintProps{
+    children:React.ReactNode;
+    text:string;
+    side?:"top" | "right" |"bottom" | "left";
+    align?:"start" | "center" | "end"
+}
+
+export const Hint=({children,text,side="top",align="center"}:HintProps)=>{
+    return(
+        <TooltipProvider>
+           <Tooltip>
+               <TooltipTrigger asChild>
+                   {children}
+               </TooltipTrigger>
+               <TooltipContent side={side} align={align}>
+                   <p>{text}</p>
+               </TooltipContent>
+           </Tooltip>
+        </TooltipProvider>
+    )
+}
+;

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,60 @@
+import { Hint } from "@/components/hint";
+import { Button } from "@/components/ui/button";
+import { Fragment } from "@/generated/prisma";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { useState } from "react";
+
+interface Props{
+    data:Fragment
+}
+
+export function FragmentWeb({data}:Props){
+    const [fragmentKey,setFragmentKey]=useState(0);
+    const [copied,setCopied]=useState(false);
+
+    const onRefresh=()=>{
+        setFragmentKey((prev)=>prev+1)
+    }
+    const handleCopy=()=>{
+        navigator.clipboard.writeText(data.sandboxUrl);
+        setCopied(true);
+        setTimeout(()=>setCopied(false),2000)
+    }
+    return(
+        <div className="flex flex-col w-full h-full">
+            <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+                <Hint text="Refresh" side="bottom" align="start">
+                <Button size="sm" variant="outline" onClick={onRefresh}>
+                    <RefreshCcwIcon />
+                </Button>
+                </Hint>
+                <Hint text="Click to copy" side="bottom">
+                <Button size="sm" variant="outline" onClick={handleCopy} disabled={false} className="flex-1 justify-start text-start font-normal">
+                    <span className="truncate">
+                        {data.sandboxUrl} 
+                    </span>
+                </Button>
+                </Hint>
+                <Hint text="Open in a new tab" side="bottom" align="start">
+                <Button
+                size="sm"
+                disabled={!data.sandboxUrl || copied}
+                variant="outline"
+                onClick={()=>{
+                    if(!data.sandboxUrl) return;
+                    window.open(data.sandboxUrl,"_blank");
+                }}>
+                <ExternalLinkIcon />
+                </Button> 
+                </Hint>
+            </div>
+           <iframe
+            key={fragmentKey}
+            className="h-full w-full"
+            sandbox="allow-forms allow-scripts allow-same-origin"
+            loading="lazy"
+            src={data.sandboxUrl}
+            />
+        </div>
+    )
+}

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -7,6 +7,7 @@ import { MessagesContainer } from "../components/messages-container";
 import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 interface Props{
     projectId:string
 }
@@ -33,7 +34,7 @@ export const ProjectView=({projectId}:Props)=>{
                 <ResizablePanel
                 defaultSize={65}
                 minSize={50}>
-                   TODO: Preview
+                  {!!activeFragment && <FragmentWeb data={activeFragment} />}
                 </ResizablePanel>
             </ResizablePanelGroup>
         </div>


### PR DESCRIPTION
feat: update ProjectView to render FragmentWeb component for active fragments in the preview section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new tooltip component for enhanced user guidance.
  * Added a preview panel for project fragments, allowing users to refresh, copy, or open sandbox URLs directly from the interface, with helpful tooltips on each action.

* **User Interface**
  * Improved the project view by displaying a live preview of active fragments when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->